### PR TITLE
Update webhook-payload.ts to fix missing "I" Rebilld -> RebillId

### DIFF
--- a/src/webhook-handler/webhook-payload.ts
+++ b/src/webhook-handler/webhook-payload.ts
@@ -11,7 +11,7 @@ export interface WebhookPayload {
   PaymentId: number;
   ErrorCode: string;
   Amount: number;
-  Rebilld?: number;
+  RebillId?: number;
   CardId: number;
   Pan: string;
   ExpDate: string;
@@ -29,7 +29,7 @@ export const webhookPayloadSchema: Schema = [
     type: PropType.IntegerFromString,
   },
   {
-    property: 'Rebilld',
+    property: 'RebillId',
     type: PropType.IntegerFromString,
     optional: true,
   },


### PR DESCRIPTION
Спасибо большое за классную либу! Опечатка в коде, нет буквы ```I``` в параметре ```RebillId```, в результате автокомплита в VS Code, использовал неверное значение, и параметр не сохранялся в MongoDB. Хорошо что я сохранял параллельно сырой ответ от апи тоже, смог восстановить значения:)

Issue: #4 